### PR TITLE
Add preferred az support in elasticcache replication group

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -81,6 +81,13 @@ func resourceAwsElasticacheReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"preferred_cache_cluster_azs": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
 		},
 	}
 }
@@ -98,9 +105,11 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 	securityNameSet := d.Get("security_group_names").(*schema.Set)
 	securityIdSet := d.Get("security_group_ids").(*schema.Set)
 	subnetGroupName := d.Get("subnet_group_name").(string)
+	prefferedCacheClusterAZs := d.Get("preferred_cache_cluster_azs").(*schema.Set)
 
 	securityNames := expandStringList(securityNameSet.List())
 	securityIds := expandStringList(securityIdSet.List())
+	prefferedAZs := expandStringList(prefferedCacheClusterAZs.List())
 
 	req := &elasticache.CreateReplicationGroupInput{
 		ReplicationGroupID:          aws.String(replicationGroupId),
@@ -113,6 +122,7 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		EngineVersion:               aws.String(engineVersion),
 		CacheSecurityGroupNames:     securityNames,
 		SecurityGroupIDs:            securityIds,
+		PreferredCacheClusterAZs:    prefferedAZs,
 	}
 
 	if v, ok := d.GetOk("parameter_group_name"); ok {


### PR DESCRIPTION
This PR add support of preferred AZs in elasticache replication group. 

Example of usage:

```
resource "aws_elasticache_replication_group" "redis" {
    replication_group_id = "${concat(var.epop, \"-redis\")}"
    description = "test-sjc-redis"
    engine = "redis"
    cache_node_type = "cache.m3.medium"
    num_cache_clusters = 2
    automatic_failover = true
    subnet_group_name = "${aws_elasticache_subnet_group.redis.name}"
    security_group_ids = ["${aws_security_group.redis.id}"]

    preferred_cache_cluster_azs = [
        "us-west-1a",
        "us-west-1c",
    ]

    depends_on = [
        "aws_elasticache_subnet_group.redis",
        "aws_security_group.redis"
    ]
}
```
