### PR TITLE
make preferred AZs optional for elasticache replication groups

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -110,11 +110,9 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 	securityNameSet := d.Get("security_group_names").(*schema.Set)
 	securityIDSet := d.Get("security_group_ids").(*schema.Set)
 	subnetGroupName := d.Get("subnet_group_name").(string)
-	prefferedCacheClusterAZs := d.Get("preferred_cache_cluster_azs").(*schema.Set)
 
 	securityNames := expandStringList(securityNameSet.List())
 	securityIds := expandStringList(securityIDSet.List())
-	prefferedAZs := expandStringList(prefferedCacheClusterAZs.List())
 
 	req := &elasticache.CreateReplicationGroupInput{
 		ReplicationGroupId:          aws.String(replicationGroupID),
@@ -128,7 +126,13 @@ func resourceAwsElasticacheReplicationGroupCreate(d *schema.ResourceData, meta i
 		EngineVersion:               aws.String(engineVersion),
 		CacheSecurityGroupNames:     securityNames,
 		SecurityGroupIds:            securityIds,
-		PreferredCacheClusterAZs:    prefferedAZs,
+	}
+
+	// preferred az's are optional and can be defaulted by AWS
+	if v, ok := d.GetOk("preferred_cache_cluster_azs"); ok {
+		prefferedCacheClusterAZs := v.(*schema.Set)
+		prefferedAZs := expandStringList(prefferedCacheClusterAZs.List())
+		req.PreferredCacheClusterAZs = PreferredAZs
 	}
 
 	// parameter groups are optional and can be defaulted by AWS


### PR DESCRIPTION
Preferred AZs are optional from an AWS API perspective.  This change makes it optional from terraform's perspective as well.
